### PR TITLE
Fix sql_flush

### DIFF
--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -368,6 +368,7 @@ class DatabaseOperations(BaseDatabaseOperations):
             return [
                 sequence
                 for sequence in self.connection.introspection.sequence_list()
+                if sequence['table'].lower() in [table.lower() for table in tables]
             ]
 
         return []


### PR DESCRIPTION
@jean-frenette-optel
Part of the solution for [OPOSM-7972](https://jira.optelgroup.com/browse/OPOSM-7972).
Just a draft PR for internal review (NB: we cannot put anything else in branch dev than the bulk insert stuff, because of https://github.com/microsoft/mssql-django/pull/107; here is the "official" PR to microsoft: https://github.com/microsoft/mssql-django/pull/112 (same content)).

The reset_sequences argument in sql_flush must be understood as relative to the tables passed, not absolute. The present fix aligns the relevant code snippet with the one from the closest impl. i.e. Oracle - cf. https://github.com/django/django/blob/795da6306a048b18c0158496b0d49e8e4f197a32/django/db/backends/oracle/operations.py#L493